### PR TITLE
Remove iterable/list deprecated rules

### DIFF
--- a/lib/analysis_options.5.0.0.yaml
+++ b/lib/analysis_options.5.0.0.yaml
@@ -82,7 +82,6 @@ linter:
     - implementation_imports
     - implicit_reopen
     - invalid_case_patterns
-    - iterable_contains_unrelated_type
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
     - library_annotations
@@ -90,7 +89,6 @@ linter:
     - library_prefixes
     - library_private_types_in_public_api
     - lines_longer_than_80_chars
-    - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

With Flutter **3.13/Dart 3.1**, the `iterable_contains_unrelated_type` and `list_remove_unrelated_type rules were deprecated`.

As the rules was merged into already defined `collection_methods_unrelated_type`, both `iterable_contains_unrelated_type` and `list_remove_unrelated_type` could be removed.

This PR closes #85

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
