### PR TITLE
feat: use latest VGA version by default in analyze script

### DIFF
--- a/tool/linter_rules/README.md
+++ b/tool/linter_rules/README.md
@@ -36,9 +36,9 @@ Rules that are missing a reason in the `exclusion_reasons.json` file will be giv
 | set-exit-if-changed | Set the exit code to 2 if there are changes to the exclusion reasons. | false                                   |
 
 
-## Inspection 🔍
+## Analyze 🔍
 
-If you're looking to update Very Good Analysis you might want to inspect the health of the latest rule set. You can use the script at `bin/inspect.dart` to do exactly that.
+If you're looking to update Very Good Analysis you might want to analyze the health of the latest rule set. You can use the script at `bin/analyze.dart` to do exactly that.
 
 It will log information about:
 
@@ -48,10 +48,17 @@ It will log information about:
 
 ### Usage
 
-To run the `inspect` script, run the following command (from `tool/linter_rules`, and don't forget to `dart pub get`):
+To run the `analyze` script, run the following command (from `tool/linter_rules`, and don't forget to `dart pub get`):
 
 ```sh
-dart bin/inspect.dart $version
+# This will analyze the latest version of Very Good Analysis
+dart bin/analyze.dart
 ```
 
-Where version is the existing Very Good Analysis version you would like to inspect, for example `9.0.0`.
+The script also accepts a specific version as an argument to analyze:
+
+```sh
+dart bin/analyze.dart $version
+```
+
+Where version is the existing Very Good Analysis version you would like to analyze, for example `9.0.0`.

--- a/tool/linter_rules/bin/analyze.dart
+++ b/tool/linter_rules/bin/analyze.dart
@@ -10,22 +10,21 @@ final Uri _allLinterRulesUri = Uri.parse(
 
 /// Compares Very Good Analysis with the all available Dart linter rules.
 ///
-/// Should be run from the root of the `linter_rules` package (tool/linter_rules),
-/// with the version of the Very Good Analysis to inspect.
+/// Should be run from the root of the `linter_rules` package (tool/linter_rules).
 ///
-/// The version argument should be in the format of `x.y.z`. For example,
-/// `5.1.0`.
 ///
 /// To use the tool run (from tool/linter_rules):
 /// ```sh
-/// dart bin/inspect.dart $version
+/// dart bin/analyze.dart
 /// ```
 ///
-/// Where `$version` is the version of the Very Good Analysis to log the table
-/// for. For example:
+/// A specific version can be analyzed by providing it as an argument,
+/// otherwise the latest version will be used.
+///
+/// For example, to analyze version `5.1.0`:
 ///
 /// ```sh
-/// dart bin/inspect.dart 5.1.0
+/// dart bin/analyze.dart 5.1.0
 /// ```
 ///
 /// It will log information about:
@@ -38,7 +37,7 @@ Future<void> main(
   List<String> args, {
   void Function(String) log = print,
 }) async {
-  final version = args[0];
+  final version = args.isNotEmpty ? args[0] : latestVgaVersion();
 
   final response = await get(_allLinterRulesUri);
   final json = jsonDecode(response.body) as List<dynamic>;


### PR DESCRIPTION
## Status

**READY**

## Description

- use latest VGA version by default in analyze script
- rename inspect script to analyze.

These changes are part of the changes to implement a better mechanism to automatically detect deprecated lint rules in the VGA #120.



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
